### PR TITLE
Added Lua tests for parameter estimation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: difftool test
 
-test: OMSimulator.log
+test: OMSimulator.log OMFit.log
 
 partest: difftool
 	cd partest && time ./runtests.pl -nocolour -with-xml
@@ -13,6 +13,7 @@ OMSimulator.log: difftool
 
 OMFit.log: difftool
 	$(MAKE) -C OMFit -f Makefile test > $@
+	grep == OMFit.log
 
 difftool:
 	$(MAKE) -C difftool

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ OMSimulator.log: difftool
 	$(MAKE) -C OMSimulator -f Makefile test > $@
 	grep == OMSimulator.log
 
+OMFit.log: difftool
+	$(MAKE) -C OMFit -f Makefile test > $@
+
 difftool:
 	$(MAKE) -C difftool

--- a/OMFit/HelloWorld_cs_Fit.lua
+++ b/OMFit/HelloWorld_cs_Fit.lua
@@ -1,0 +1,67 @@
+-- name: HelloWorld_cs_Fit
+-- status: correct
+-- teardown_command: rm HelloWorld_cs_Fit.log
+
+-- Uncomment below if script shall be executed by a standard Lua interpreter (see README.md)
+-- require("package")
+-- OMSimulatorLua = package.loadlib("../../install/linux/lib/libOMSimulatorLua.so", "luaopen_OMSimulatorLua")
+-- OMSimulatorLua()
+-- OMFitLua = package.loadlib("../../install/linux/lib/libOMFitLua.so", "luaopen_OMFitLua")
+-- OMFitLua()
+
+setLogFile("HelloWorld_cs_Fit.log")
+
+version = getVersion()
+-- print(version)
+
+model = newModel()
+setTempDirectory(".")
+setTolerance(model, 1e-5);
+
+-- instantiate FMU
+instantiateFMU(model, "../FMUs/HelloWorld_cs.fmu", "HelloWorld")
+
+-- create fitmodel for model
+fitmodel = omsfit_newFitModel(model);
+-- omsfit_describe(fitmodel)
+
+-- Data generated from simulating HelloWorld.mo for 1.0s with Euler and 0.1s step size
+kNumSeries = 1;
+kNumObservations = 11;
+data_time = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1};
+inputvars = {};
+measurementvars = {"HelloWorld.x"};
+data_x = {1, 0.9, 0.8100000000000001, 0.7290000000000001, 0.6561, 0.5904900000000001, 0.5314410000000001, 0.4782969000000001, 0.43046721, 0.387420489, 0.3486784401};
+
+omsfit_initialize(fitmodel, kNumSeries, data_time, inputvars, measurementvars)
+-- omsfit_describe(fitmodel)
+
+omsfit_addParameter(fitmodel, "HelloWorld.x_start", 0.5);
+omsfit_addParameter(fitmodel, "HelloWorld.a", -0.5);
+omsfit_addMeasurement(fitmodel, 0, "HelloWorld.x", data_x);
+-- omsfit_describe(fitmodel)
+
+omsfit_setOptions_max_num_iterations(fitmodel, 25)
+omsfit_solve(fitmodel, "")
+
+status, fitmodelstate = omsfit_getState(fitmodel);
+-- print(status, fitmodelstate)
+
+status, startvalue1, estimatedvalue1 = omsfit_getParameter(fitmodel, "HelloWorld.a")
+status, startvalue2, estimatedvalue2 = omsfit_getParameter(fitmodel, "HelloWorld.x_start")
+-- print("HelloWorld.a startvalue=" .. startvalue1 .. ", estimatedvalue=" .. estimatedvalue1)
+-- print("HelloWorld.x_start startvalue=" .. startvalue2 .. ", estimatedvalue=" .. estimatedvalue2)
+is_OK1 = estimatedvalue1 > -1.1 and estimatedvalue1 < -0.9
+is_OK2 = estimatedvalue2 > 0.9 and estimatedvalue2 < 1.1
+print("HelloWorld.a estimation is OK: " .. tostring(is_OK1))
+print("HelloWorld.x_start estimation is OK: " .. tostring(is_OK2))
+
+omsfit_freeFitModel(fitmodel)
+terminate(model)
+unload(model)
+
+-- Result:
+-- HelloWorld.a estimation is OK: true
+-- HelloWorld.x_start estimation is OK: true
+-- info: Logging information has been saved to "HelloWorld_cs_Fit.log"
+-- endResult

--- a/OMFit/Makefile
+++ b/OMFit/Makefile
@@ -1,0 +1,47 @@
+TEST = ../rtest -v
+
+TESTFILES = \
+HelloWorld_cs_Fit.lua \
+
+# Run make failingtest
+FAILINGTESTFILES = \
+
+# Dependency files that are not .lua or Makefile
+# Add them here or they will be cleaned.
+DEPENDENCIES = \
+*.lua \
+*.xml \
+Makefile \
+README.md \
+
+CLEAN = `ls | grep -w -v -f deps.tmp`
+
+.PHONY : test clean getdeps failingtest
+
+test:
+	@echo
+	@echo Running tests...
+	@$(TEST) $(TESTFILES)
+
+# Cleans all files that are not listed as dependencies
+clean:
+	@echo $(DEPENDENCIES) | sed 's/ /\\\|/g' > deps.tmp
+	@rm -rf $(CLEAN)
+
+# Run this if you want to list out the files (dependencies).
+# do it after cleaning and updating the folder
+# then you can get a list of file names (which must be dependencies
+# since you got them from repository + your own new files)
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
+	@echo $(DEPENDENCIES) | sed 's/ /\\\|/g' > deps.tmp
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
+	@echo Dependency list saved in deps.txt.
+	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
+
+failingtest:
+	@echo
+	@echo Running failing tests...
+	@echo
+	@$(TEST) $(FAILINGTESTFILES)

--- a/OMFit/README.md
+++ b/OMFit/README.md
@@ -1,6 +1,11 @@
-# Tests for the OMFit module C-API bindings
+# Tests for the OMFit module
 
-This folder contains tests for the OMFit module that can be executed by cmake/ctest, see CMakeLists.txt, e.g., in the OMSimulator build directory do:
+This folder contains tests for the OMFit module.
+
+## Tests for the OMFit module C-API bindings
+
+The tests that directly use the C-API can be executed by cmake/ctest, see
+CMakeLists.txt, e.g., in the OMSimulator build directory do:
 
 ```shell
 ctest -V
@@ -13,4 +18,27 @@ shared libraries), e.g.:
 
 ```shell
 ./runRoot.sh ../../src/OMFitLib/test_HelloWorld_cs_Fit.c
+```
+
+# Tests for the OMFit module using the Lua bindings
+
+The Lua scripts use the Lua bindings to the OMFit C-API for parameter estimation.
+
+The OMSimulator binary already contains a Lua interpreter including the Lua bindings
+to the OMFit library (if it has been built with the _optional_ OMFit module).
+Hence, scripts can be simply executed like shown below:
+
+```shell
+/my/path/to/OMSimulator HelloWorld_cs_Fit.lua
+```
+
+The scripts can also be executed by a standard Lua interpreter. In this case
+the libraries need to be loaded similarly as shown below:
+
+```lua
+require("package")
+OMSimulatorLua = package.loadlib("../../install/linux/lib/libOMSimulatorLua.so", "luaopen_OMSimulatorLua")
+OMSimulatorLua()
+OMFitLua = package.loadlib("../../install/linux/lib/libOMFitLua.so", "luaopen_OMFitLua")
+OMFitLua()
 ```


### PR DESCRIPTION
This PR provides a new make target for executing a Lua parameter estimation test:

```shell
make OMFit.log
```

This new target is not part of the default target. It would be possible to include it into the default target if that seems to be beneficial.