### PR TITLE
Adapted DualMassOscillatorEq_cs example to oms2 API

### DIFF
--- a/API/DualMassOscillatorEq_cs_oms2.lua
+++ b/API/DualMassOscillatorEq_cs_oms2.lua
@@ -1,0 +1,48 @@
+-- status: correct
+-- teardown_command: rm DualMassOscillatorEq_cs_oms2.log DualMassOscillatorEq_cs_oms2.mat
+-- linux: yes
+
+oms2_setLogFile("DualMassOscillatorEq_cs_oms2.log")
+
+status = oms2_setTempDirectory("./DualMassOscillatorEq_cs_oms2_tmp")
+
+status = oms2_newFMIModel("DualMass")
+
+-- add FMUs
+status = oms2_addFMU("DualMass", "../FMUs/DualMassOscillator.System1Eq_cs.fmu", "System1")
+status = oms2_addFMU("DualMass", "../FMUs/DualMassOscillator.System2Eq_cs.fmu", "System2")
+
+-- add connections
+status = oms2_addConnection("DualMass", "System1:in_F", "System2:out_F")
+status = oms2_addConnection("DualMass", "System1:out_s1", "System2:in_s1")
+status = oms2_addConnection("DualMass", "System1:out_v1", "System2:in_v1")
+
+status = oms2_setResultFile("DualMass", "DualMassOscillatorEq_cs_oms2.mat")
+
+stopTime = 0.1
+status = oms2_setStopTime("DualMass", stopTime)
+status = oms2_setCommunicationInterval("DualMass", 1e-5)
+
+-- Master algorithm variants:
+-- standard : The single-task standard
+-- pctpl : task pool approach using CTPL library (https://github.com/vit-vit/CTPL)
+-- status = oms2_setMasterAlgorithm("DualMass", "standard")
+
+
+status = oms2_initialize("DualMass")
+status = oms2_simulate("DualMass")
+
+vars = {"DualMass.System1:s1", "DualMass.System2:s2"}
+for _,var in ipairs(vars) do
+  print(var .. " at " .. stopTime .. ": " .. oms2_getReal(var))
+end
+
+oms2_terminate("DualMass")
+
+oms2_unloadModel("DualMass")
+
+-- Result:
+-- DualMass.System1:s1 at 0.1: -0.45012153166449
+-- DualMass.System2:s2 at 0.1: -0.30237070431675
+-- info:    Logging information has been saved to "DualMassOscillatorEq_cs_oms2.log"
+-- endResult

--- a/API/Makefile
+++ b/API/Makefile
@@ -5,6 +5,7 @@ api-test01.lua \
 api-test02.lua \
 api-test03.lua \
 api-test04.lua \
+DualMassOscillatorEq_cs_oms2.lua \
 
 # Run make failingtest
 FAILINGTESTFILES = \


### PR DESCRIPTION
@lochel

I created a version of the DualMassOscillatorEq_cs example using the oms2 API.

It is prepared for my extension which allows to select a different master algorithm, but this lines are disabled, so it can be executed with the present master.

The test throws an error during the call of `status = oms2_initialize("DualMass")`.

If one removes all `oms2_addConnection(..)` statements, except for the first one, initialization and simulation run without errors.