### PR TITLE
Changed ports on TLM test model

### DIFF
--- a/OMTLMSimulator/TLM_FMI_1D_CoarseGrained.lua
+++ b/OMTLMSimulator/TLM_FMI_1D_CoarseGrained.lua
@@ -33,7 +33,7 @@ oms2_addFMISubModel("tlm1d_cg", "fmi2")
 oms2_addTLMInterface("tlm1d_cg", "fmi1", "P", 1, bidirectional, "Mechanical", "fmu:position", "fmu:velocity", "fmu:wave", "fmu:impedance")
 oms2_addTLMInterface("tlm1d_cg", "fmi2", "P", 1, bidirectional, "Mechanical", "fmu:position", "fmu:velocity", "fmu:wave", "fmu:impedance")
 oms2_addTLMConnection("tlm1d_cg", "fmi1:P", "fmi2:P", 1e-4, 0.0, 0.1, 0)
-oms2_setTLMSocketData("tlm1d_cg","127.0.1.1",11132,12132)
+oms2_setTLMSocketData("tlm1d_cg","127.0.1.1",11152,12152)
 
 -- oms2_describe("tlm1d_cg")
 


### PR DESCRIPTION
Two test models were using the same ports, which in some cases can make them fail. 