### PR TITLE
Updated TLM testmodels for zero errors

### DIFF
--- a/OMTLMSimulator/TLM_External_Tools.lua
+++ b/OMTLMSimulator/TLM_External_Tools.lua
@@ -58,7 +58,5 @@ end
 -- adder.y is equal
 -- source1.y is equal
 -- source2.y is equal
--- info:    0 warnings
--- info:    1 errors
 -- info:    Logging information has been saved to "TLM_External_Tools.log"
 -- endResult

--- a/OMTLMSimulator/TLM_FMI_1D.lua
+++ b/OMTLMSimulator/TLM_FMI_1D.lua
@@ -54,7 +54,5 @@ end
 -- fmi2.P.v [m/s] is equal
 -- fmi1.P.F [N] is equal
 -- fmi2.P.F [N] is equal
--- info:    0 warnings
--- info:    1 errors
 -- info:    Logging information has been saved to "TLM_FMI_1D.log"
 -- endResult

--- a/OMTLMSimulator/TLM_FMI_1D_CoarseGrained.lua
+++ b/OMTLMSimulator/TLM_FMI_1D_CoarseGrained.lua
@@ -65,7 +65,5 @@ end
 -- fmi2.P.v [m/s] is equal
 -- fmi1.P.F [N] is equal
 -- fmi2.P.F [N] is equal
--- info:    0 warnings
--- info:    1 errors
 -- info:    Logging information has been saved to "TLM_FMI_1D_CoarseGrained.log"
 -- endResult

--- a/OMTLMSimulator/TLM_FMI_1D_FineGrained.lua
+++ b/OMTLMSimulator/TLM_FMI_1D_FineGrained.lua
@@ -77,7 +77,5 @@ end
 -- fmi2.P.v [m/s] is equal
 -- fmi1.P.F [N] is equal
 -- fmi2.P.F [N] is equal
--- info:    0 warnings
--- info:    1 errors
 -- info:    Logging information has been saved to "TLM_FMI_1D_FineGrained.log"
 -- endResult

--- a/OMTLMSimulator/TLM_FMI_3D.lua
+++ b/OMTLMSimulator/TLM_FMI_3D.lua
@@ -70,7 +70,5 @@ end
 -- fmi2.P.R[cG][cG](1) [m] is equal
 -- fmi2.P.R[cG][cG](2) [m] is equal
 -- fmi2.P.R[cG][cG](3) [m] is equal
--- info:    0 warnings
--- info:    1 errors
 -- info:    Logging information has been saved to "TLM_FMI_3D.log"
 -- endResult

--- a/OMTLMSimulator/TLM_FMI_3D_FineGrained.lua
+++ b/OMTLMSimulator/TLM_FMI_3D_FineGrained.lua
@@ -79,7 +79,5 @@ end
 -- Manager thread finished.
 -- fmi1.P.R[cG][cG](1) [m] is equal
 -- fmi1.P.R[cG][cG](2) [m] is equal
--- info:    0 warnings
--- info:    1 errors
 -- info:    Logging information has been saved to "TLM_FMI_3D_FineGrained.log"
 -- endResult

--- a/OMTLMSimulator/TLM_FMI_Submodels.lua
+++ b/OMTLMSimulator/TLM_FMI_Submodels.lua
@@ -63,7 +63,5 @@ end
 -- Manager thread finished.
 -- fmi1.out is equal
 -- fmi2.out is equal
--- info:    0 warnings
--- info:    1 errors
 -- info:    Logging information has been saved to "TLM_FMI_Submodels.log"
 -- endResult


### PR DESCRIPTION
There are no longer any errors in the output, since TLMCompositeModel::terminate() is now implemented.