### PR TITLE
Add an option to rtest to run the win target from mingw

### DIFF
--- a/API/api-test01.lua
+++ b/API/api-test01.lua
@@ -2,6 +2,7 @@
 -- teardown_command:
 -- linux: yes
 -- mingw: yes
+-- win: yes
 -- mac: yes
 
 oms2_setLoggingLevel(1)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all difftool
+.PHONY: all test difftool partest
 
 all: difftool test
 

--- a/partest/runtest.pl
+++ b/partest/runtest.pl
@@ -28,6 +28,9 @@ for(@ARGV){
   elsif(/-have-dwdiff/) {
     $rtest_extra_args = $rtest_extra_args . " -c";
   }
+  elsif(/-win/) {
+    $rtest_extra_args = $rtest_extra_args . " -win";
+  }
   elsif(/^--with-omc=(.*)$/) {
     $rtest_extra_args = $rtest_extra_args . " --with-omc=$1";
   }
@@ -239,7 +242,7 @@ while(<$test_log>) {
   elsif(/== Failed to set baseline.*time: (\d*)/) {
     $nfailed = 1;
     $time = $2;
-  }  
+  }
   elsif(/.*time: (\d*)/) {
     $nfailed = 0;
     $time = $1;

--- a/partest/runtests.pl
+++ b/partest/runtests.pl
@@ -55,6 +55,7 @@ my $with_xml_cmd = 0;
 my $withtxt = 0;
 my $have_dwdiff = "";
 my $rebase_test = "";
+my $win = "";
 
 {
   eval { require File::Which; 1; };
@@ -86,6 +87,7 @@ for(@ARGV){
     print("  -nodb         Don't store timing data.\n");
     print("  -nosavedb     Don't overwrite stored timing data.\n");
     print("  -veryfew      Run only a very small number of tests to see if runtests.pl is working.\n");
+    print("  -win          Force to use the VS version of OMSimulator.\n");
     print("  -with-txt     Output TXT log.\n");
     print("  -with-xml     Output XML log.\n");
     exit 1;
@@ -123,6 +125,9 @@ for(@ARGV){
   }
   elsif(/^-veryfew$/) {
     $veryfew = 1;
+  }
+  elsif(/^-win$/) {
+    $win = "-win";
   }
   elsif(/^-with-txt$/) {
     $withtxt = 1;
@@ -239,7 +244,7 @@ sub run_tests {
     (my $test_dir, my $test) = $test_full =~ /(.*)\/([^\/]*)$/;
 
     my $t0 = [gettimeofday];
-    my $cmd = "$testscript $test_full $have_dwdiff $nocolour $with_xml_cmd $rebase_test";
+    my $cmd = "$testscript $test_full $have_dwdiff $nocolour $with_xml_cmd $rebase_test $win";
     my $x = system("$cmd") >> 8;
     my $elapsed = tv_interval ( $t0, [gettimeofday]);
 

--- a/rtest
+++ b/rtest
@@ -9,24 +9,25 @@ if ($cwd =~ m/(.*)testsuite\/(.+)$/) {
   $dirname = $2;
   $os = `uname`;
   if ($os =~ /MINGW/) {
-    $PLATFORM = "mingw";
+    $PLATFORM1 = "mingw";
   }
   else {
     if ($os =~ /Darwin/) {
-      $PLATFORM = "mac";
+      $PLATFORM1 = "mac";
     }
     else {
-      $PLATFORM = "linux";
+      $PLATFORM1 = "linux";
     }
   }
+  $PLATFORM2 = $PLATFORM1;
 } else {
   print "You must run rtest from OMSimulator (was run from $cwd)\n";
   exit 0;
 }
 
-system "$prefix/install/$PLATFORM/bin/omc-diff -v1.4";
+system "$prefix/install/$PLATFORM1/bin/omc-diff -v1.4";
 if ($?) {
-  print "$prefix/install/$PLATFORM/bin/omc-diff seems to be missing or of an incompatible version.\n";
+  print "$prefix/install/$PLATFORM1/bin/omc-diff seems to be missing or of an incompatible version.\n";
   print "Compile omc-diff and run rtest again.\n";
   exit 2;
 }
@@ -117,7 +118,7 @@ sub setbaselineone
       $env =~ s/:/\\;/g;
     }
     unlink "$testTempFile$f";
-    system "$env $ulimit $prefix/install/$PLATFORM/bin/$sim_exe $f >>$log 2>&1";
+    system "$env $ulimit $prefix/install/$PLATFORM2/bin/$sim_exe $f >>$log 2>&1";
     if ($nodelete == 0 && open(TOREMOVE,"<$testTempFile$f")) {
       while(my $line = <TOREMOVE>) {
         $line =~ s/^\s*(.*?)\s*$/$1/;
@@ -207,7 +208,7 @@ sub runone
       $env =~ s/:/\\;/g;
     }
     unlink "$testTempFile$f";
-    system "$env $ulimit $prefix/install/$PLATFORM/bin/$sim_exe $f >>$log 2>&1";
+    system "$env $ulimit $prefix/install/$PLATFORM2/bin/$sim_exe $f >>$log 2>&1";
     $retval = $?;
     if ($nodelete==0 && open(TOREMOVE,"<$testTempFile$f")) {
       while(my $line = <TOREMOVE>) {
@@ -248,7 +249,7 @@ sub runone
     close RES;
 
     # Compare
-    system "$prefix/install/$PLATFORM/bin/omc-diff $epsilon $expected $got > $difference";
+    system "$prefix/install/$PLATFORM1/bin/omc-diff $epsilon $expected $got > $difference";
 
     if ( $? != 0 ) {
     print "equation mismatch [time:$end_t]\n";
@@ -377,7 +378,7 @@ sub dofile
       return 1;
     }
 
-    if ($info{$PLATFORM} eq "yes") {
+    if ($info{$PLATFORM2} eq "yes") {
       if ($setbaseline) {
         setbaselineone $f,%info;
         $status = 0;
@@ -410,6 +411,8 @@ while ($#ARGV >= 0) {
       $returnwitherror=1;
     } elsif ($arg eq "-v") {
       $verbose="yes";
+    } elsif ($arg eq "-win") {
+      $PLATFORM2="win";
     } elsif ($arg eq "-b") {
       $setbaseline = 1;
     } elsif ($arg eq "-c") {


### PR DESCRIPTION
### Purpose

This introduces a new option (`rtest -win` / `runtests.pl -win`) to run the testsuite using the mingw toolchain but the VS-based OMSimulator.
Tests can be activated for this by using `win: yes` inside the test header.