### PR TITLE
Set logging interval in TLM testmodels

### DIFF
--- a/OMTLMSimulator/TLM_External_Tools.lua
+++ b/OMTLMSimulator/TLM_External_Tools.lua
@@ -31,6 +31,7 @@ oms2_setTLMSocketData("tlm_ext","127.0.1.1",11142,12142)
 
 oms2_setStartTime("tlm_ext", 0.5)
 oms2_setStopTime("tlm_ext", 4)
+oms2_setLoggingInterval("tlm_ext", 1e-4)
 
 oms2_initialize("tlm_ext")
 oms2_simulate("tlm_ext")

--- a/OMTLMSimulator/TLM_FMI_1D.lua
+++ b/OMTLMSimulator/TLM_FMI_1D.lua
@@ -30,6 +30,7 @@ oms2_setTLMSocketData("tlm1d","127.0.1.1",11132,12132)
 
 oms2_setStartTime("tlm1d", 0)
 oms2_setStopTime("tlm1d", 2)
+oms2_setLoggingInterval("tlm1d", 1e-4)
 
 oms2_initialize("tlm1d")
 oms2_simulate("tlm1d")

--- a/OMTLMSimulator/TLM_FMI_1D_CoarseGrained.lua
+++ b/OMTLMSimulator/TLM_FMI_1D_CoarseGrained.lua
@@ -41,6 +41,7 @@ oms2_setTLMSocketData("tlm1d_cg","127.0.1.1",11152,12152)
 
 oms2_setStartTime("tlm1d_cg", 0)
 oms2_setStopTime("tlm1d_cg", 0.5)
+oms2_setLoggingInterval("tlm1d_cg", 1e-4)
 
 oms2_initialize("tlm1d_cg")
 oms2_simulate("tlm1d_cg")

--- a/OMTLMSimulator/TLM_FMI_1D_FineGrained.lua
+++ b/OMTLMSimulator/TLM_FMI_1D_FineGrained.lua
@@ -53,6 +53,7 @@ oms2_setTLMSocketData("tlm1d_fg","127.0.1.1",11162,12162)
 
 oms2_setStartTime("tlm1d_fg", 0)
 oms2_setStopTime("tlm1d_fg", 0.5)
+oms2_setLoggingInterval("tlm1d_fg", 1e-4)
 
 oms2_initialize("tlm1d_fg")
 oms2_simulate("tlm1d_fg")

--- a/OMTLMSimulator/TLM_FMI_3D.lua
+++ b/OMTLMSimulator/TLM_FMI_3D.lua
@@ -44,6 +44,7 @@ oms2_setTLMSocketData("tlm3d","127.0.1.1",11122,12122)
 
 oms2_setStartTime("tlm3d", 0)
 oms2_setStopTime("tlm3d", 0.1)
+oms2_setLoggingInterval("tlm3d", 1e-4)
 
 oms2_initialize("tlm3d")
 oms2_simulate("tlm3d")

--- a/OMTLMSimulator/TLM_FMI_3D_FineGrained.lua
+++ b/OMTLMSimulator/TLM_FMI_3D_FineGrained.lua
@@ -58,6 +58,7 @@ oms2_setTLMSocketData("tlm3d_fg","127.0.1.1",11172,12172)
 
 oms2_setStartTime("tlm3d_fg", 0)
 oms2_setStopTime("tlm3d_fg", 1)
+oms2_setLoggingInterval("tlm3d_fg", 1e-4)
 
 oms2_initialize("tlm3d_fg")
 oms2_simulate("tlm3d_fg")

--- a/OMTLMSimulator/TLM_FMI_Submodels.lua
+++ b/OMTLMSimulator/TLM_FMI_Submodels.lua
@@ -41,6 +41,7 @@ oms2_setTLMSocketData("tlm","127.0.1.1",11112,12112)
 
 oms2_setStartTime("tlm", 0)
 oms2_setStopTime("tlm", 1)
+oms2_setLoggingInterval("tlm", 1e-4)
 
 oms2_initialize("tlm")
 oms2_simulate("tlm")


### PR DESCRIPTION
Update to TLM models required since default logging changed from interval=1e-4 to samples=1000.

Related to OpenModelica/OMSimulator#231